### PR TITLE
Pass SRTSOCKET to callback connectors by pointer and not value

### DIFF
--- a/pkg/callbacks.go
+++ b/pkg/callbacks.go
@@ -26,7 +26,7 @@ var (
 // For groups only
 // https://github.com/Haivision/srt/blob/master/docs/API/API-functions.md#srt_connect_callback
 func (s *Socket) SetConnectCallback(c ConnectCallback) (err error) {
-	if err = cConnectCallback(s.u); err != nil {
+	if err = cConnectCallback(&s.u); err != nil {
 		return
 	}
 	connectCallbacksMutex.Lock()
@@ -89,7 +89,7 @@ func go2cListenCallback(opaque unsafe.Pointer, u C.SRTSOCKET, version C.int, pee
 
 // https://github.com/Haivision/srt/blob/master/docs/API/API-functions.md#srt_listen_callback
 func (s *Socket) SetListenCallback(c ListenCallback) (err error) {
-	if err = cListenCallback(s.u); err != nil {
+	if err = cListenCallback(&s.u); err != nil {
 		return
 	}
 	listenCallbacksMutex.Lock()

--- a/pkg/wrap.go
+++ b/pkg/wrap.go
@@ -111,20 +111,20 @@ func cAccept(s C.SRTSOCKET, addr *C.struct_sockaddr, size *C.int) (C.SRTSOCKET, 
 	return ret, nil
 }
 
-func cListenCallback(lsn C.SRTSOCKET) error {
+func cListenCallback(lsn *C.SRTSOCKET) error {
 	var srtErrno C.int
 	var sysErrno C.int
-	ret := C.astisrt_listen_callback(lsn, unsafe.Pointer(&lsn), &srtErrno, &sysErrno)
+	ret := C.astisrt_listen_callback(*lsn, unsafe.Pointer(lsn), &srtErrno, &sysErrno)
 	if ret == C.SRT_ERROR_ {
 		return newError(srtErrno, sysErrno)
 	}
 	return nil
 }
 
-func cConnectCallback(clr C.SRTSOCKET) error {
+func cConnectCallback(clr *C.SRTSOCKET) error {
 	var srtErrno C.int
 	var sysErrno C.int
-	ret := C.astisrt_connect_callback(clr, unsafe.Pointer(&clr), &srtErrno, &sysErrno)
+	ret := C.astisrt_connect_callback(*clr, unsafe.Pointer(clr), &srtErrno, &sysErrno)
 	if ret == C.SRT_ERROR_ {
 		return newError(srtErrno, sysErrno)
 	}


### PR DESCRIPTION
Previously, behavior was undefined, and in my case, it would lead to these callbacks no longer operating.

This is because by passing the SRTSOCKET to `cListenCallback` and `cConnectCallback` by value, we were storing the pointer of the temporary function argument, and not the actual parent function's variable.

Fixes #3 